### PR TITLE
add @type argument to FlInput

### DIFF
--- a/addon/components/fl-input/fl-input.hbs
+++ b/addon/components/fl-input/fl-input.hbs
@@ -17,7 +17,14 @@
             </label>
         {{/if}}
     {{else}}
-        <Input @value={{@value}} class="{{this.inputBaseClass}}" id={{this.id}} name={{this.name}} ...attributes />
+        <Input
+            @value={{@value}}
+            @type={{this.type}}
+            class="{{this.inputBaseClass}}"
+            id={{this.id}}
+            name={{this.name}}
+            ...attributes
+        />
         {{#if this.placeholder}}
             <label class="control-label fl-placeholder-label" for={{this.id}}>
                 {{this.placeholder}}

--- a/addon/components/fl-input/fl-input.ts
+++ b/addon/components/fl-input/fl-input.ts
@@ -16,6 +16,7 @@ export interface FlInputArgs {
     inset?: boolean;
     id?: string;
     name?: string;
+    type?: string;
     errors?: string[];
 }
 
@@ -63,6 +64,10 @@ export default class FlInput<T extends FlInputArgs> extends Component<T> {
 
     get placeholder(): string | undefined {
         return this.firstError ?? this.args.placeholder;
+    }
+
+    get type(): string {
+        return this.args.type ?? 'text';
     }
 
     /**

--- a/addon/components/fl-input/fl-input.ts
+++ b/addon/components/fl-input/fl-input.ts
@@ -8,6 +8,30 @@ import { isEmpty } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+export type HTMLInputType =
+    | 'button'
+    | 'checkbox'
+    | 'color'
+    | 'date'
+    | 'datetime-local'
+    | 'email'
+    | 'file'
+    | 'hidden'
+    | 'image'
+    | 'month'
+    | 'number'
+    | 'password'
+    | 'radio'
+    | 'range'
+    | 'reset'
+    | 'search'
+    | 'submit'
+    | 'tel'
+    | 'text'
+    | 'time'
+    | 'url'
+    | 'week';
+
 export interface FlInputArgs {
     value: any;
     placeholder?: string;
@@ -16,7 +40,7 @@ export interface FlInputArgs {
     inset?: boolean;
     id?: string;
     name?: string;
-    type?: string;
+    type?: HTMLInputType;
     errors?: string[];
 }
 
@@ -66,7 +90,7 @@ export default class FlInput<T extends FlInputArgs> extends Component<T> {
         return this.firstError ?? this.args.placeholder;
     }
 
-    get type(): string {
+    get type(): HTMLInputType {
         return this.args.type ?? 'text';
     }
 

--- a/tests/integration/components/fl-input-test.ts
+++ b/tests/integration/components/fl-input-test.ts
@@ -19,6 +19,6 @@ module('Integration | Component | fl-input', function (hooks) {
         await render(hbs`<FlInput @placeholder="password" @type="password"/>`);
         await a11yAudit();
         const inputElement = this.element.querySelector('input') as HTMLInputElement;
-        assert.equal(inputElement.type, 'password');
+        assert.strictEqual(inputElement.type, 'password');
     });
 });

--- a/tests/integration/components/fl-input-test.ts
+++ b/tests/integration/components/fl-input-test.ts
@@ -14,4 +14,11 @@ module('Integration | Component | fl-input', function (hooks) {
         await a11yAudit();
         assert.strictEqual(this.element.textContent?.trim(), 'test');
     });
+
+    test('Type attribute is set on the <input> when using <FlInput />', async function (assert) {
+        await render(hbs`<FlInput @placeholder="password" @type="password"/>`);
+        await a11yAudit();
+        const inputElement = this.element.querySelector('input') as HTMLInputElement;
+        assert.equal(inputElement.type, 'password');
+    });
 });


### PR DESCRIPTION
Ember's `<Input>` component has `type` as an argument, updated FlInput to pass in `@type`.
https://guides.emberjs.com/release/components/built-in-components/#toc_setting-attributes-on-input